### PR TITLE
serve index.html from `/`

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -31,13 +31,19 @@ server {
     # directory into our docker image /data/assets.
     #
 
-    # /home
-    # redirect to /app/assets/index.html
-    location = /home {
+    # /
+    # respond with /app/assets/index.html
+    location = / {
         # don't cache so the most uptodate js files are requested
         add_header Cache-Control "no-cache";
         root /app/assets;
         try_files /index.html =404;
+    }
+
+    # /home
+    # depreciated - redirect to /
+    location = /home {
+        return 301 /;
     }
 
     # /data


### PR DESCRIPTION
https://github.com/digi-serve/ab_service_api_sails/issues/147
If approved will make this change in `#master` as well
## Release Notes
<!-- #release_notes -->
- serve index.html from `/` instead of `/home`
- `/home` redirects to `/` for campatibility
<!-- /release_notes --> 

## Test Status
See note in https://github.com/digi-serve/ab_service_api_sails/pull/148
